### PR TITLE
[Improvement] Xcode Indentation 설정 보강

### DIFF
--- a/docs/Common.md
+++ b/docs/Common.md
@@ -32,7 +32,7 @@
 
 - Indent는 2칸으로 지정합니다.
 - Xcode에서 **Preferences -> Text Editing -> Display -> Line wrapping** 부분을 2 spaces로 설정해서 사용해주세요.
-- Xcode에서 **Preferences -> Text Editing -> Indentation** 부분의 **Prefer Indent Using**부분을 'Spaces'로, **Tab Width**와 **Indent Width** 부분을 2 spaces로 설정해서 사용해주세요.
+- Xcode에서 **Preferences -> Text Editing -> Indentation** 부분의 **Prefer Indent Using** 부분을 'Spaces'로, **Tab Width**와 **Indent Width** 부분을 2 spaces로 설정해서 사용해주세요.
 
 ### Guard 규칙
 

--- a/docs/Common.md
+++ b/docs/Common.md
@@ -32,6 +32,7 @@
 
 - Indent는 2칸으로 지정합니다.
 - Xcode에서 **Preferences -> Text Editing -> Display -> Line wrapping** 부분을 2 spaces로 설정해서 사용해주세요.
+- Xcode에서 **Preferences -> Text Editing -> Indentation** 부분의 **Prefer Indent Using**부분을 'Spaces'로, **Tab Width**와 **Indent Width** 부분을 2 spaces로 설정해서 사용해주세요.
 
 ### Guard 규칙
 


### PR DESCRIPTION
이전에는 기존 가이드의 들여쓰기 규칙에 있는 내용만 설정해도 들여쓰기가 잘 적용되었는데, Xcode 새 버전 문제인지는 몰라도 파일 생성시 해당 파일이 Indent 설정이 제대로 적용되지 않는 문제가 있어 이를 수정하기 위한 들여쓰기 설정 가이드를 보강하였습니다. 

해당 설정으로 Indent 설정이 제대로 적용되는지는 @JoosungPark 과 확인하였습니다.